### PR TITLE
build: Disable `trailing_whitespace` swiftlint rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -105,7 +105,7 @@ only_rules:
   - trailing_semicolon
 
   # Lines should not have trailing whitespace.
-  - trailing_whitespace
+  # - trailing_whitespace
 
   # Type bodies should not span too many lines.
   # - type_body_length


### PR DESCRIPTION
We need to silent `trailing_whitespace` warning
![Screen Shot 2022-07-29 at 6 33 52 PM](https://user-images.githubusercontent.com/45182214/181804402-62cb1678-0cd3-4c26-91df-7f2c3bc2d63b.png)
 