### PR TITLE
build: Add Cosmos View with a Bridge Stars View ⭐️

### DIFF
--- a/UIDokan/Package.swift
+++ b/UIDokan/Package.swift
@@ -19,6 +19,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(url: "https://github.com/Juanpe/SkeletonView.git", from: "1.7.0"),
+        .package(url: "https://github.com/evgenyneu/Cosmos.git", from: "23.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -27,6 +28,7 @@ let package = Package(
             name: "UIDokan",
             dependencies: [
                 "SkeletonView",
+                "Cosmos",
             ]
         ),
         .testTarget(

--- a/UIDokan/Sources/UIDokan/ReusableViews/StarsView.swift
+++ b/UIDokan/Sources/UIDokan/ReusableViews/StarsView.swift
@@ -1,0 +1,13 @@
+//
+//  StarsView.swift
+//
+//
+//  Created by Ahmed M. Hassan on 14/08/2022.
+//
+
+import Cosmos
+import Foundation
+
+/// Bridge to access `CosmosView` to avoid coupling in the project
+///
+public class StarsView: CosmosView {}


### PR DESCRIPTION
- Integrate Cosmos in the UIDokan
- Add Stars View to avoid Cosmos decoupling in the project.